### PR TITLE
Change conduct link to absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # A Dataset of Humanity's Favourite Numbers
 
-Please note that this project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms
+Please note that this project is released with a [Contributor Code of Conduct](http://github.com/Ironholds/favnums/blob/master/CONDUCT.md). By participating in this project you agree to abide by its terms


### PR DESCRIPTION
This should allow the version shown on CRAN to link to the code of conduct; it currently results in a 404 on CRAN.
